### PR TITLE
Add --inputFiles support outside clean command

### DIFF
--- a/modules/app/src/commands/bucket-generator-command.js
+++ b/modules/app/src/commands/bucket-generator-command.js
@@ -26,7 +26,7 @@ class BucketGeneratorCommand {
 
     this.executionPath = program.executionDirectory || '.';
     this.outputFile = program.outputFile || this.executionPath + '/' + DEFAULT_TEST_RUNTIME_FILE;
-
+    this.inputFiles = program.inputFiles || [this.executionPath + '/' + DEFAULT_TEST_RUNTIME_FILE];
     this.verbose = program.verbose || false;
   }
 
@@ -36,7 +36,11 @@ class BucketGeneratorCommand {
     }
 
     // Load all runtime jsons into memory
-    const testRuntimes = parseRuntimeFile(this.outputFile);
+    const testRuntimes = {};
+    this.inputFiles.forEach((inputFile) => {
+      const inputFileRuntimes = parseRuntimeFile(inputFile);
+      Object.assign(testRuntimes, inputFileRuntimes);
+    });
 
     // Calculate the average test runtime
     const averageRuntime = Object.keys(testRuntimes).reduce((runtimeTotal, runtimeDataKey) => {

--- a/modules/app/src/commands/runtime-cleaner-command.js
+++ b/modules/app/src/commands/runtime-cleaner-command.js
@@ -5,12 +5,14 @@ const {
   parseRuntimeFile,
   writeRuntimeFile,
 } = require('../util/file-util');
+const TestBucketGenerator = require('./bucket-generator-command');
 
 class RuntimeCleanerCommand {
   constructor(program) {
     this.executionPath = program.executionDirectory || '.';
     this.outputFile = program.outputFile || this.executionPath + '/' + DEFAULT_TEST_RUNTIME_FILE;
     this.inputFiles = program.inputFiles || [this.executionPath + '/' + DEFAULT_TEST_RUNTIME_FILE];
+    this.testFileArray = new TestBucketGenerator(program).run();
     this.verbose = program.verbose || false;
   }
 


### PR DESCRIPTION
Use js-test-runtime.json or the --inputFiles parameter instead of the output file when generating test runtimes. Also fixed an error where the test files array was previously removed when simplifying.

<!-- probot = {"487052":{"current_lock":false}} -->