### PR TITLE
Parse jest time

### DIFF
--- a/modules/app/src/commands/runtime-generator-command.js
+++ b/modules/app/src/commands/runtime-generator-command.js
@@ -54,8 +54,7 @@ class RuntimeGeneratorCommand {
     }
   }
 
-  parseTestRuntime(testOutput) {
-    const runtimeRegEx = new RegExp(/^.* passing \((\d*)(ms|m|s)\)/, 'm');
+  mochaParseTestRuntime(runtimeRegEx, testOutput) {
     const runtimeMatch = testOutput.match(runtimeRegEx);
     let runtimeValue = Number.parseFloat(runtimeMatch[1]);
     if (runtimeMatch[2] === 's') {
@@ -64,6 +63,35 @@ class RuntimeGeneratorCommand {
       runtimeValue *= 60 * 1000;
     }
     return runtimeValue;
+  }
+
+  jestParseTestRuntime(runtimeRegEx, testOutput) {
+    console.log(testOutput);
+    const runtimeMatch = testOutput.match(runtimeRegEx);
+    let runtimeValue = Number.parseFloat(runtimeMatch[1]);
+    if (runtimeMatch[2] === 's') {
+      runtimeValue *= 1000;
+    } else if (runtimeMatch[2] === 'm') {
+      runtimeValue *= 60 * 1000;
+    }
+    return runtimeValue;
+  }
+
+  parseTestRuntime(testOutput) {
+    console.log('parseTestRuntime');
+    console.log(testOutput);
+    console.log('parseTestRuntime');
+
+    const mochaRuntimeRegEx = new RegExp(/^.* passing \((\d*)(ms|m|s)\)/, 'm');
+    const jestRuntimeRegEx = new RegExp(/^.*Time:.*?(\d*\.?\d*?)(ms|m|s)/, 'm');
+
+    if (jestRuntimeRegEx.test(testOutput)) {
+      return this.jestParseTestRuntime(jestRuntimeRegEx, testOutput);
+    }
+
+    if (mochaRuntimeRegEx.test(testOutput)) {
+      return this.mochaParseTestRuntime(mochaRuntimeRegEx, testOutput);
+    }
   }
 
   runTest(testFileName) {

--- a/modules/app/src/commands/runtime-generator-command.js
+++ b/modules/app/src/commands/runtime-generator-command.js
@@ -66,7 +66,6 @@ class RuntimeGeneratorCommand {
   }
 
   jestParseTestRuntime(runtimeRegEx, testOutput) {
-    console.log(testOutput);
     const runtimeMatch = testOutput.match(runtimeRegEx);
     let runtimeValue = Number.parseFloat(runtimeMatch[1]);
     if (runtimeMatch[2] === 's') {
@@ -78,10 +77,6 @@ class RuntimeGeneratorCommand {
   }
 
   parseTestRuntime(testOutput) {
-    console.log('parseTestRuntime');
-    console.log(testOutput);
-    console.log('parseTestRuntime');
-
     const mochaRuntimeRegEx = new RegExp(/^.* passing \((\d*)(ms|m|s)\)/, 'm');
     const jestRuntimeRegEx = new RegExp(/^.*Time:.*?(\d*\.?\d*?)(ms|m|s)/, 'm');
 

--- a/modules/app/src/commands/runtime-generator-command.js
+++ b/modules/app/src/commands/runtime-generator-command.js
@@ -54,18 +54,7 @@ class RuntimeGeneratorCommand {
     }
   }
 
-  mochaParseTestRuntime(runtimeRegEx, testOutput) {
-    const runtimeMatch = testOutput.match(runtimeRegEx);
-    let runtimeValue = Number.parseFloat(runtimeMatch[1]);
-    if (runtimeMatch[2] === 's') {
-      runtimeValue *= 1000;
-    } else if (runtimeMatch[2] === 'm') {
-      runtimeValue *= 60 * 1000;
-    }
-    return runtimeValue;
-  }
-
-  jestParseTestRuntime(runtimeRegEx, testOutput) {
+  parseTestOutput(runtimeRegEx, testOutput) {
     const runtimeMatch = testOutput.match(runtimeRegEx);
     let runtimeValue = Number.parseFloat(runtimeMatch[1]);
     if (runtimeMatch[2] === 's') {
@@ -81,11 +70,11 @@ class RuntimeGeneratorCommand {
     const jestRuntimeRegEx = new RegExp(/^.*Time:.*?(\d*\.?\d*?)(ms|m|s)/, 'm');
 
     if (jestRuntimeRegEx.test(testOutput)) {
-      return this.jestParseTestRuntime(jestRuntimeRegEx, testOutput);
+      return this.parseTestOutput(jestRuntimeRegEx, testOutput);
     }
 
     if (mochaRuntimeRegEx.test(testOutput)) {
-      return this.mochaParseTestRuntime(mochaRuntimeRegEx, testOutput);
+      return this.parseTestOutput(mochaRuntimeRegEx, testOutput);
     }
   }
 

--- a/modules/app/test/commands/runtime-generator-command-test.js
+++ b/modules/app/test/commands/runtime-generator-command-test.js
@@ -1,0 +1,20 @@
+const RuntimeGeneratorCommand = require('../../src/commands/runtime-generator-command');
+const program = require('commander');
+
+describe('RuntimeGeneratorCommand', () => {
+  describe('.parseTestRuntime', () => {
+    it('works for mocha output', () => {
+      const command = new RuntimeGeneratorCommand(program);
+      expect(command.parseTestRuntime('1 passing (6ms)')).toEqual(6);
+      expect(command.parseTestRuntime('1 passing (1s)')).toEqual(1000);
+      expect(command.parseTestRuntime('1 passing (1m)')).toEqual(60000);
+    });
+
+    it('works for jest output', () => {
+      const command = new RuntimeGeneratorCommand(program);
+      expect(command.parseTestRuntime('Time:        8ms')).toEqual(8);
+      expect(command.parseTestRuntime('Time:        8.476s')).toEqual(8476);
+      expect(command.parseTestRuntime('Time:        5.612m')).toEqual(336720);
+    });
+  });
+});


### PR DESCRIPTION
Adapts the test timing to parse mocha or jest output. root-mobile is using jest now for all tests and need to fix to allow the timing pipeline to function. Timing pipeline test run here: https://buildkite.com/root-insurance/root-mobile-test-timing/builds/154

