### PR TITLE
run first test twice to remove jest cache times from tests

### DIFF
--- a/modules/app/src/commands/runtime-generator-command.js
+++ b/modules/app/src/commands/runtime-generator-command.js
@@ -27,6 +27,13 @@ class RuntimeGeneratorCommand {
 
     const testRuntimes = {};
     const testFailureArray = [];
+
+    /**
+     * Jest needs to generate a cache that can take 2 minutes to build on the first test run.
+     * We run the first test to force the cache to generate so that we get more accurate test times.
+     */
+    this.runTest(this.testFileArray[0]);
+
     this.testFileArray.forEach((currentTestFile, index, array) => {
       console.log('%s/%s: Starting Test: %s\r\n', index + 1, array.length, currentTestFile);
       const testData = this.runTest(currentTestFile);


### PR DESCRIPTION
Tim discussed an issue with me today where some test times were taking much longer than they should have.  My theory is that this is due to the Jest cache.  Here's some terminal output from me testing the Jest cache times locally:

```
lmcglone@Levis-MacBook-Pro:~/code/root-mobile [master ↓·6|⚑ 53] $ yarn test modules/global/test/routing/deep-links/routes/hash-test.js --no-cache
yarn run v1.22.4
$ jest --runInBand modules/global/test/routing/deep-links/routes/hash-test.js --no-cache
 PASS   enzyme  modules/global/test/routing/deep-links/routes/hash-test.js (95.986s)
  Hash deep link object
    isSceneAllowed
      ✓ returns true (3ms)
    isSceneReady
      ✓ returns true
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        104.319s
✨  Done in 108.45s.
lmcglone@Levis-MacBook-Pro:~/code/root-mobile [master ↓·6|⚑ 53] $ yarn test modules/global/test/routing/deep-links/routes/hash-test.js
yarn run v1.22.4
$ jest --runInBand modules/global/test/routing/deep-links/routes/hash-test.js
 PASS   enzyme  modules/global/test/routing/deep-links/routes/hash-test.js (6.231s)
  Hash deep link object
    isSceneAllowed
      ✓ returns true (3ms)
    isSceneReady
      ✓ returns true
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        7.954s
✨  Done in 9.30s.
```

There's a lot of overhead here for the first test case in the suite.  This caching should only happen on the first test case in the suite, but ~90s * 20 buckets = 30 minutes of extra run time that is not accurate to the amount of time the tests actually take to run.

Jest cache time: 95.986s - 6.231s = 89.755 seconds of cache time

Looking at the numbers, it looks like jest might have a few seconds of start/stop time as well, but I don't think we can do much there without a larger refactor where we run all of the tests in one go and parse the Jest output.

I think this should rebalance the test buckets better than what we have currently.