### PR TITLE
add better regex to stop detox tests from running

### DIFF
--- a/modules/app/src/commands/bucket-generator-command.js
+++ b/modules/app/src/commands/bucket-generator-command.js
@@ -15,7 +15,7 @@ class BucketGeneratorCommand {
     if (!program.testFiles || program.testFiles.length === 0) {
       this.testDirectoryBase = '.';
       this.testFileArray = findTestFiles(this.testDirectoryBase);
-    } else if (program.testFiles.some((testFile) => testFile.indexOf('test.js') > -1)) {
+    } else if (program.testFiles.some((testFile) => testFile.indexOf('-test.js') > -1)) {
       this.testFileArray = program.testFiles;
     } else {
       this.testDirectoryBase = program.testFiles;

--- a/modules/app/src/util/file-util.js
+++ b/modules/app/src/util/file-util.js
@@ -1,4 +1,4 @@
-const { executeCommand } = require('../util/execute-command');
+const {executeCommand} = require('../util/execute-command');
 const fs = require('fs');
 const path = require('path');
 
@@ -6,7 +6,7 @@ const DEFAULT_TEST_RUNTIME_FILE_PREFIX = 'js-test-runtime';
 const DEFAULT_TEST_RUNTIME_FILE = DEFAULT_TEST_RUNTIME_FILE_PREFIX + '.json';
 
 function findTestFiles(testDirectory = '.') {
-  const findCommandOutput = executeCommand('find ' + testDirectory + ' -path ./node_modules -prune -o -type f -name "*test.js"');
+  const findCommandOutput = executeCommand('find ' + testDirectory + ' -path ./node_modules -prune -o -type f -name "*-test.js"');
   const testFileArray = _generateFormattedFindFilePaths(findCommandOutput.toString());
   return testFileArray.filter((file) => !!file);
 }


### PR DESCRIPTION
Here is a build where this was run:

https://buildkite.com/root-insurance/root-mobile-test-timing/builds/176#8a78970f-4f2b-4ea4-b561-343961696bab

This fixes failing timing builds due to detox tests that are suffixed with -detoxtest.js.

We should not run Detox tests in Buildkite.