### PR TITLE
Reverting times generated by file-util.js back to miliseconds

### DIFF
--- a/modules/app/src/util/file-util.js
+++ b/modules/app/src/util/file-util.js
@@ -46,7 +46,7 @@ function _generateOrderedRuntimesFileString(testRuntimeObject) {
 
   const sortedRuntimeKeys = Object.keys(testRuntimeObject).sort((a, b) => testRuntimeObject[b] - testRuntimeObject[a]);
   sortedRuntimeKeys.forEach((runtimeKey, index) => {
-    fileString += `${fileSpacer}"${runtimeKey}": ${testRuntimeObject[runtimeKey] / 1000}`;
+    fileString += `${fileSpacer}"${runtimeKey}": ${testRuntimeObject[runtimeKey]}`;
     if (index !== sortedRuntimeKeys.length - 1) {
       fileString += ',';
     }


### PR DESCRIPTION
The times output was changed to seconds for the monorepo migration of root-mobile. However due to other issues found after migration, we are reverting this back to ms.